### PR TITLE
Develop

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,0 +1,83 @@
+.. about_
+
+About PyTroll-Schedule
+======================
+
+Case of One Receiving Station
+-----------------------------
+In the case of a single station, the procedure of scheduling is quite 
+straightforward. However, let us describe it in detail here, such that the
+background will be set for the more complex case of multiple reception station 
+reception scheduling.
+
+The first step to compute the schedule, is to know which satellites of interest 
+are going to be rising above the horizon during the duration of the schedule. 
+In order to find such cases, we retrieve the orbital information for each 
+satellite of interest and apply orbit prediction using the aiaa sgp4 algorithm 
+(ref). In practice, we use norad tle files (ref) as orbital elements, and the 
+python implementation of the sgp4 algorithm provided in pyorbital (ref). From 
+this, we then obtain a list of the coming overpasses for the station. We define 
+an overpass as a risetime and fall time for a given satellite, during which it 
+will be within reception reach of the station.
+
+Now, we have to find the possible schedules for the station. The set of all 
+overpasses gives us all the reception possibilities for the station. However, 
+many of them will be in conflict with at least one other overpass and will be 
+a concurrent to the reception race. We say that two overpasses conflict when 
+the risetime dog one of them is comprised within the view time of the second. 
+In case of conflicts, the scheduling algorithm has to choose one or the other 
+overpass. However, in the case of several overpasses conflicting sequentially, 
+we have to find the possible paths through the conflicting zone. In order to do 
+that, we will use graph theory algorithms.
+
+We define the graph of the conflicting zone with overpasses as vertices and 
+create an edge between two conflicting overpasses. To find the possible 
+non-conflicting combinations in this graph is actually searching for maximal 
+cliques in the complementary graph, for which we use the Bron-Kerbosch 
+algorithm.
+#illustration click
+
+we obtain thus groups of passes that are not conflicting in the time frame.
+The next step is to find the optimal list of non conflicting passes under the 
+duration on the schedule.
+
+Cases of Connected Stations
+---------------------------
+There are several ways to computate schedules for connected stations, two are
+implemented in this program.
+
+Several points should be considered:
+* Technical equipement, reception of L-band, Ku-band, X-band?
+* Geographic location, nearby or large distance between?
+
+"Master-Slave" Operation
+************************
+The mode of master-slave is best suited for two stations, located next to each
+other, with similar technical systems.
+
+In this case a schedule for one, namely the "master" station, would be computed,
+as if it were only this one station.
+
+In a second step this schedule plan is used as a substraction list when 
+computing the schedule for the second, the "slave" station.
+
+Co-operating Stations
+*********************
+A mode of co-operating stations can consider the distance between different
+geographical locations and differences in technical equipement, most notable
+different reception capabilities (X- & L-band vs. L-band).
+
+In this case, each station defines a time span requirement for each pass. Then, 
+if a connected station can fulfil this requirement and is scheduling the same 
+pass, we can say that the stations are redundant. To avoid such redundancy, we 
+can define ways to synchronise the schedule to optimise the intake of data and 
+fulfil the pareto condition.
+A simple protocol can be used to perform this: both A and B provide alternatives 
+and compute the enhanced score for the schedule including the others pass.
+
+B can delegate the pass only if it can assure that the time span requirement of 
+A is respected.
+
+This operation can be extended to more than two stations, all receiving a 
+single-operation schedule and an individual cooperating-schedule.
+

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,151 @@
+Configuration
+=============
+
+The configuration file is divided in several section, each titled with a name 
+in square brackets. All sections are filled with key=value pairs.
+
+Required sections are ``default`` and ``pattern``, all others are referenced by
+the station list in section ``default`` and the satellites lists in the sections
+per station.
+
+Main section "default"
+------------------------
+::
+
+	[default]
+	station=nrk,ofb
+	forward=12
+	start=1
+
+``forward``
+	The timespan in hours the schedule should cover.
+
+``start``
+	Time offset between the time of computing and start of the schedule.
+
+File- and directory pattern
+---------------------------
+Each of the keys in this section can be referenced from within other lines in 
+this section.
+
+.. note::
+
+   Be carefull not to create loops!
+	
+::
+
+	[pattern]
+	dir_output= {output_dir}/{date}-{time}
+	dir_plots= {dir_output}/plots.{station}
+	file_xml= {dir_output}/aquisition-schedule-{mode}_{station}.xml
+	file_sci= {dir_output}/scisys-schedule-{station}.txt
+	file_graph= {dir_output}/graph.{station}
+
+``time``, ``date``
+	Time+date, when the computation started.
+	
+``station``
+	Replaced with the station name. For co-operating stations "combined 
+	schedule" the string ".comb" is appended.
+
+``mode``
+	If a schedule file was created in `request` mode or in `report` mode.
+	The first one is the format accepted by SciSYS software, while
+	`report` mode is good for monitoring purposes.
+
+``output_dir``
+	This placeholder references the command-line argument ``-o OUTPUT_DIR``.
+
+``dir_output``
+	This key is used only within this section.
+
+``dir_plots``
+	Where the plots (globe grafic files) are saved.
+
+``file_xml``
+	Path and filename format for xml-schedule (request and report).
+
+``file_sci``
+	Path and filename for schedule file in SciSYS format.
+
+``file_graph``
+	Graph files with information about the computation.
+
+
+Stations
+--------
+::
+	
+	[ofb]
+	name=offenbach
+	longitude=8.747073
+	latitude=50.103095
+	altitude=0.140
+	area_file=/home/troll/etc/areas.def
+	area=euro4
+	satellites=metop-a,metop-b,noaa 19,noaa 18,noaa 15,aqua,terra,suomi npp
+
+``name``
+	Name of the station.
+	
+``longitude``
+	Longitude in degrees east.
+
+``latitude``
+	Longitude in degrees north.
+	
+``altitude``
+	Altitude above mean sea level, in km.
+	
+``area_file``, ``area``
+	File with area definitions, and the area referenced therein.
+	This area is taken into computation, only satellite passes which swaths
+	are cross-sectioning this area are considered for scheduling.
+
+``satellites``
+	List of satellites receivable from this station. The listed names refer to 
+	the satellite sections.
+
+::
+	
+	[nrk]
+	name=norrkoeping
+	longitude=16.148649
+	latitude=58.581844
+	altitude=0.052765
+	area_file=/home/troll/etc/areas.def
+	area=euron1
+	satellites=metop-a,metop-b,noaa 19,noaa 18,noaa 15,aqua,terra,suomi npp
+
+While the above section contained values for the station Offenbach/Germany, 
+this section has values for Norkoepping/Sweden.
+
+Satellites
+----------
+::
+	
+	[metop-a]
+	night=0.1
+	day=0.6
+	
+	[noaa 19]
+	night=0.05
+	day=0.3
+	
+	[terra]
+	night=0.2
+	day=0.8
+	
+	[suomi npp]
+	night=0.25
+	day=0.9
+	
+A few examples for satellite sections.
+
+``night``
+	Weight value for satellite swath parts on the night-side of the terminator.
+
+``day``
+	Weight value for satellite swath parts on the day-side of the terminator.
+
+	

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -1,0 +1,53 @@
+Example
+=======
+
+This Bash-script shows an example how to use the schedule script::
+
+	#!/usr/bin/bash
+	. $HOME/.bash_profile
+	bin=$HOME/.local/bin/schedule
+	conf=$PYTROLL_BASE/etc-schedule
+	logp=$PYTROLL_BASE/log/scheduler.log
+	logc=$PYTROLL_BASE/log/create.log
+	odir=$PYTROLL_BASE/schedules
+	
+	cfgfile=$1
+	shift
+	
+	# report-mode with plots
+	mode="-r -p"
+	
+	# min time-diff btwn passes
+	delay="90"
+	
+	# create output for scisys
+	sci="--scisys"
+	
+	# dont include aqua-dumps
+	aqua="--no-aqua-dump"
+	
+	# write gv-files for dot
+	graph="-g"
+	
+	# exit if no new tle
+	(( `ls $PYTROLL_BASE/tle/*.tle 2>/dev/null|wc -l` > 0 )) || exit 0
+	
+	# catch newest TLE-file, remove others
+	tle=`ls -t $PYTROLL_BASE/tle/*.tle|head -1`
+	mv $tle $tle.txt
+	rm -f $PYTROLL_BASE/tle/*.tle
+	
+	# settings for TLE-check
+	satlst="NOAA 15|NOAA 18|NOAA 19|METOP-A|METOP-B|AQUA|SUOMI|TERRA "
+	satcnt=8
+	to_addr=pytroll@schedule
+	
+	# check if TLE-file is complete
+	if (( `grep -P "$satlst" $tle.txt|tee .tle_grep|wc -l` != $satcnt )); then
+	    exit 0
+	else
+	    tle="-t $tle.txt"
+	fi
+	
+	# start schedule script
+	$bin -v -l $logp -c $conf/$cfgfile $tle -d $delay -o $odir $graph $mode $sci $aqua $@

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,40 +6,21 @@
 Welcome to pytroll-schedule's documentation!
 ============================================
 
-Usage of the schedule script::
-
-  usage: schedule [-h] [--lon LON] [--lat LAT] [--alt ALT] [-l LOG] [-v]
-                  [-t TLE] [-f FORWARD] [-s START_TIME] [-d DELAY] [-c CONFIG]
-                  [-x XML] [--scisys SCISYS]
-
-  optional arguments:
-    -h, --help            show this help message and exit
-    --lon LON             Longitude, degrees east
-    --lat LAT             Latitude, degrees north
-    --alt ALT             Altitude, km
-    -l LOG, --log LOG     File to log to (defaults to stdout)
-    -v, --verbose         print debug messages too
-    -t TLE, --tle TLE     tle file to use
-    -f FORWARD, --forward FORWARD
-                          time ahead to compute the schedule
-    -s START_TIME, --start-time START_TIME
-                          start time of the schedule to compute
-    -d DELAY, --delay DELAY
-                          delay (in seconds) needed between two consecutive
-                          passes (60 seconds by default)
-    -c CONFIG, --config CONFIG
-                          configuration file to use
-
-  output:
-    -x XML, --xml XML     generate an xml request file and put it in this
-                          directory
-    --scisys SCISYS       path to the schedule file
-
+Reception scheduling of polar weather satellites.
 
 Contents:
 
 .. toctree::
    :maxdepth: 2
+   
+   about
+
+.. toctree::
+   :maxdepth: 1
+   
+   usage
+   config
+   example
 
 Indices and tables
 ==================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,31 @@
+Installation
+============
+	mkdir $HOME/PyTROLL
+	cd !$
+	mkdir data-in data-out etc
+	
+	#dnf install pyshp python-configobj numpy numpy-f2py scipy python-numexpr \
+	#python-pillow proj proj-epsg proj-nad pyproj python2-matplotlib python-basemap
+	#
+	wget https://github.com/pytroll/mipp/archive/master.zip -O mipp-master.zip
+	wget https://github.com/pytroll/mpop/archive/pre-master.zip -O mpop-pre-master.zip
+	wget https://github.com/pytroll/pyresample/archive/master.zip -O pyresample-master.zip
+	wget https://github.com/adybbroe/python-geotiepoints/archive/master.zip -O python-geotiepoints-master.zip
+	wget https://github.com/pytroll/pycoast/archive/master.zip -O pycoast-master.zip
+	wget https://github.com/pytroll/pyorbital/archive/master.zip -O pyorbital-master.zip
+	wget https://github.com/pytroll/trollcast/archive/master.zip -O trollcast-master.zip
+	wget https://github.com/pytroll/pytroll-schedule/archive/master.zip -O pytroll-schedule-master.zip
+	wget https://github.com/pytroll/trollduction/archive/master.zip -O trollduction-master.zip
+	
+	
+	for ff in *.zip ; do
+	   unzip -u $ff
+	   cd $(basename $ff .zip)
+	   python setup.py build
+	   python setup.py install --user
+	done
+	
+	cat <<EE
+	export PPP_CONFIG_DIR=$HOME/PyTROLL/etc
+	export XRIT_DECOMPRESS_OUTDIR=$HOME/PyTROLL/data-out
+	EE > $HOME/.pytroll.rc

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,56 @@
+Usage
+=====
+
+Usage of the schedule script::
+
+	usage: schedule [-h] [-c CONFIG] [-t TLE] [-l LOG] [-m [MAIL [MAIL ...]]] [-v]
+	                [--lat LAT] [--lon LON] [--alt ALT] [-f FORWARD]
+	                [-s START_TIME] [-d DELAY] [-a AVOID] [--no-aqua-dump]
+	                [--multiproc] [-o OUTPUT_DIR] [-u OUTPUT_URL] [-x] [-r]
+	                [--scisys] [-p] [-g]
+	
+	optional arguments:
+	  -h, --help            show this help message and exit
+	  -c CONFIG, --config CONFIG
+	                        configuration file to use
+	  -t TLE, --tle TLE     tle file to use
+	  -l LOG, --log LOG     File to log to (defaults to stdout)
+	  -m [MAIL [MAIL ...]], --mail [MAIL [MAIL ...]]
+	                        mail address(es) to send error messages to.
+	  -v, --verbose         print debug messages too
+	
+	start-parameter:
+	  (or set values in the configuration file)
+	
+	  --lat LAT             Latitude, degrees north
+	  --lon LON             Longitude, degrees east
+	  --alt ALT             Altitude, km
+	  -f FORWARD, --forward FORWARD
+	                        time ahead to compute the schedule
+	  -s START_TIME, --start-time START_TIME
+	                        start time of the schedule to compute
+	  -d DELAY, --delay DELAY
+	                        delay (in seconds) needed between two consecutive
+	                        passes (60 seconds by default)
+	
+	special:
+	  (additional parameter changing behaviour)
+	
+	  -a AVOID, --avoid AVOID
+	                        xml request file with passes to avoid
+	  --no-aqua-dump        do not consider Aqua-dumps
+	  --multiproc           use multiple parallel processes
+	
+	output:
+	  (file pattern are taken from configuration file)
+	
+	  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
+	                        where to put generated files
+	  -u OUTPUT_URL, --output-url OUTPUT_URL
+	                        URL where to put generated schedule file(s), otherwise
+	                        use output-dir
+	  -x, --xml             generate an xml request file (schedule)
+	  -r, --report          generate an xml report file (schedule)
+	  --scisys              generate a SCISYS schedule file
+	  -p, --plot            generate plot images
+	  -g, --graph           save graph info

--- a/reqreader.xsl
+++ b/reqreader.xsl
@@ -8,8 +8,19 @@
     <html>
       <head>
         <meta charset="UTF-8" />
-        <title>Überflugplan
-        </title>
+        <title>Überflugplan</title>
+        <style>
+          body { font-family:sans-serif; font-size:10pt; font-weight:normal; }
+          h1 { font-size:16pt; font-weight:bold; }
+          h2 { font-size:12pt; font-weight:bold; }
+          div.header { position:fixed; max-height:15%; }
+          div.passes { position:absolute; height:85%; bottom:0px; overflow:auto; width:45%; margin-left:2%; font-family:monospace; }
+          div.plot { position:fixed; width:50%; top:200px; right:0px; text-align:center; }
+          div.plot_rmk { position:fixed; width:50%; top:300px; right:0px; text-align:center; }
+          img.plot_img { width:600px; height:450px; visibility:hidden; }
+          .rec_true { font-weight:bold; }
+          .rec_false { font-weight:normal; }
+        </style>
         <script type="text/javascript">
           function switcher(src) {
           bild = document.getElementById("plot");
@@ -19,7 +30,7 @@
         </script>
       </head>
       <body>
-        <div style="position:fixed; height:15%; ">
+        <div class="header">
           <h1>Überflugplan</h1>
           <h2>
             Erstellt von:
@@ -32,43 +43,40 @@
             <xsl:value-of select="properties/station" />
           </h2>
         </div>
-        <div style="position:absolute; height:85%; bottom:0px; overflow:auto; width:45%; margin-left:2%; ">
+        <div class="passes">
           <table style="border-spacing:12px;">
             <tr>
               <th>Pass</th>
               <th>Satellit</th>
-              <th>Aufnahme-Anfang</th>
-              <th>Aufnahme-Ende</th>
+              <th>Datum</th>
+              <th>Anfang</th>
+              <th>Ende</th>
             </tr>
             <xsl:apply-templates select="child::node()" />
           </table>
         </div>
-        <div style="position:fixed; width:50%; top:300px; right:0px; text-align:center;">
+        <div class="plot_rmk">
           (Click auf Überflug zeigt Plot)
         </div>
-        <div style="position:fixed; width:50%; top:200px; right:0px; text-align:center; ">
-          <img id="plot" src="" style="width:600px; height:450px; visibility:hidden;" />
+        <div class="plot">
+          <img id="plot" src="" class="plot_img" />
         </div>
       </body>
     </html>
   </xsl:template>
 
-  <xsl:attribute-set name="css">
-    <xsl:attribute name="style">font-size:10pt;</xsl:attribute>
-  </xsl:attribute-set>
-
   <xsl:template match="pass">
     <xsl:variable name="plotname">
-      <xsl:value-of select="substring-after(./@img, 'plots.ofb' )" />
+      <xsl:value-of select="substring-after(./@img, 'plots.' )" />
     </xsl:variable>
     <xsl:element name="tr">
-      <xsl:attribute name="onClick">javascript:switcher('plots.ofb<xsl:value-of select="$plotname" />')</xsl:attribute>
+      <xsl:attribute name="onClick">javascript:switcher('plots.<xsl:value-of select="$plotname" />')</xsl:attribute>
       <xsl:choose>
         <xsl:when test="./@rec = 'True'">
-          <xsl:attribute name="style">font-family:monospace; font-weight:bold;</xsl:attribute>
+          <xsl:attribute name="class">rec_true</xsl:attribute>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:attribute name="style">font-family:monospace; font-weight:normal;</xsl:attribute>
+          <xsl:attribute name="class">rec_false</xsl:attribute>
         </xsl:otherwise>
       </xsl:choose>
       <xsl:call-template name="passvalues">
@@ -82,14 +90,17 @@
     <td>
       <xsl:number format="1" />
     </td>
-    <xsl:element name="td" use-attribute-sets="css">
+    <xsl:element name="td">
       <xsl:value-of select="./@satellite" />
     </xsl:element>
-    <xsl:element name="td" use-attribute-sets="css">
-      <xsl:value-of select="./@start-time" />
+    <xsl:element name="td">
+      <xsl:value-of select="substring(@start-time, 0, 11)" />
     </xsl:element>
-    <xsl:element name="td" use-attribute-sets="css">
-      <xsl:value-of select="./@end-time" />
+    <xsl:element name="td">
+      <xsl:value-of select="substring(@start-time, 12)" />
+    </xsl:element>
+    <xsl:element name="td">
+      <xsl:value-of select="substring(@end-time, 12)" />
     </xsl:element>
   </xsl:template>
 

--- a/reqreader.xsl
+++ b/reqreader.xsl
@@ -87,9 +87,9 @@
 
   <xsl:template name="passvalues">
     <xsl:param name="sat" />
-    <td>
+    <xsl:element name="td">
       <xsl:number format="1" />
-    </td>
+    </xsl:element>
     <xsl:element name="td">
       <xsl:value-of select="./@satellite" />
     </xsl:element>

--- a/reqreader.xsl
+++ b/reqreader.xsl
@@ -1,97 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" indent="yes" encoding="UTF-8" />
+  <!-- Formatting aquisition-schedule-report_ofb.xml for nice display in browser. -->
+  <!-- DWD/amaul 13.09.2016 -->
+  <xsl:output method="html" indent="yes" encoding="UTF-8" />
 
-	<xsl:template match="acquisition-schedule">
-		<html>
-			<head>
-				<meta charset="UTF-8" />
-				<title>Überflugplan
-				</title>
-				<script type="text/javascript">
-					function switcher(src) {
-					bild = document.getElementById("plot");
-					bild.src = src;
-					bild.visible = true;
-					}
-				</script>
-			</head>
-			<body>
-				<h1>Überflugplan</h1>
-				<h2>
-					Erstellt von:
-					<xsl:value-of select="properties/requested-by" />
-					um:
-					<xsl:value-of select="properties/requested-on" />
-				</h2>
-				<h2>
-					Antenne:
-					<xsl:value-of select="properties/station" />
-				</h2>
-				<table width="90%">
-					<tr>
-						<td>
-							<table style="border-spacing:12px;">
-								<tr>
-									<th>Pass</th>
-									<th>Satellit</th>
-									<th>Aufgang</th>
-									<th>Untergang</th>
-								</tr>
-								<xsl:apply-templates select="child::node()" />
-							</table>
-						</td>
-						<td valign="top" align="right" width="30%">
-							<img id="plot" src="" width="400px" height="300px" visible="false" />
-						</td>
-					</tr>
-				</table>
-			</body>
-		</html>
-	</xsl:template>
+  <xsl:template match="acquisition-schedule">
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>Überflugplan
+        </title>
+        <script type="text/javascript">
+          function switcher(src) {
+          bild = document.getElementById("plot");
+          bild.src = src;
+          bild.style.visibility = "visible";
+          }
+        </script>
+      </head>
+      <body>
+        <div style="position:fixed; height:15%; ">
+          <h1>Überflugplan</h1>
+          <h2>
+            Erstellt von:
+            <xsl:value-of select="properties/requested-by" />
+            um:
+            <xsl:value-of select="properties/requested-on" />
+          </h2>
+          <h2>
+            Antenne:
+            <xsl:value-of select="properties/station" />
+          </h2>
+        </div>
+        <div style="position:absolute; height:85%; bottom:0px; overflow:auto; width:45%; margin-left:2%; ">
+          <table style="border-spacing:12px;">
+            <tr>
+              <th>Pass</th>
+              <th>Satellit</th>
+              <th>Aufnahme-Anfang</th>
+              <th>Aufnahme-Ende</th>
+            </tr>
+            <xsl:apply-templates select="child::node()" />
+          </table>
+        </div>
+        <div style="position:fixed; width:50%; top:300px; right:0px; text-align:center;">
+          (Click auf Überflug zeigt Plot)
+        </div>
+        <div style="position:fixed; width:50%; top:200px; right:0px; text-align:center; ">
+          <img id="plot" src="" style="width:600px; height:450px; visibility:hidden;" />
+        </div>
+      </body>
+    </html>
+  </xsl:template>
 
-	<xsl:attribute-set name="css">
-		<xsl:attribute name="style">font-size:10pt;</xsl:attribute>
-	</xsl:attribute-set>
+  <xsl:attribute-set name="css">
+    <xsl:attribute name="style">font-size:10pt;</xsl:attribute>
+  </xsl:attribute-set>
 
-	<xsl:template match="pass">
-		<xsl:variable name="plotfullname">
-			<xsl:value-of select="./@img" />
-		</xsl:variable>
-		<xsl:variable name="plotname">
-			<xsl:value-of select="substring-after($plotfullname, 'plots.ofb' )" />
-		</xsl:variable>
-		<xsl:element name="tr">
-			<xsl:attribute name="onClick">javascript:switcher('plots.ofb<xsl:value-of select="$plotname" />')</xsl:attribute>
-			<xsl:choose>
-				<xsl:when test="./@rec = 'True'">
-					<xsl:attribute name="style">font-family:monospace; font-weight:bold;</xsl:attribute>
-				</xsl:when>
-				<xsl:otherwise>
-					<xsl:attribute name="style">font-family:monospace; font-weight:normal;</xsl:attribute>
-				</xsl:otherwise>
-			</xsl:choose>
-			<xsl:call-template name="passvalues">
-				<xsl:with-param name="sat" select="." />
-			</xsl:call-template>
-		</xsl:element>
-	</xsl:template>
+  <xsl:template match="pass">
+    <xsl:variable name="plotname">
+      <xsl:value-of select="substring-after(./@img, 'plots.ofb' )" />
+    </xsl:variable>
+    <xsl:element name="tr">
+      <xsl:attribute name="onClick">javascript:switcher('plots.ofb<xsl:value-of select="$plotname" />')</xsl:attribute>
+      <xsl:choose>
+        <xsl:when test="./@rec = 'True'">
+          <xsl:attribute name="style">font-family:monospace; font-weight:bold;</xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="style">font-family:monospace; font-weight:normal;</xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:call-template name="passvalues">
+        <xsl:with-param name="sat" select="." />
+      </xsl:call-template>
+    </xsl:element>
+  </xsl:template>
 
-	<xsl:template name="passvalues">
-		<xsl:param name="sat" />
-		<td>
-			<xsl:number format="1" />
-		</td>
-		<xsl:element name="td" use-attribute-sets="css">
-			<xsl:value-of select="./@satellite" />
-		</xsl:element>
-		<xsl:element name="td" use-attribute-sets="css">
-			<xsl:value-of select="./@start-time" />
-		</xsl:element>
-		<xsl:element name="td" use-attribute-sets="css">
-			<xsl:value-of select="./@end-time" />
-		</xsl:element>
-	</xsl:template>
+  <xsl:template name="passvalues">
+    <xsl:param name="sat" />
+    <td>
+      <xsl:number format="1" />
+    </td>
+    <xsl:element name="td" use-attribute-sets="css">
+      <xsl:value-of select="./@satellite" />
+    </xsl:element>
+    <xsl:element name="td" use-attribute-sets="css">
+      <xsl:value-of select="./@start-time" />
+    </xsl:element>
+    <xsl:element name="td" use-attribute-sets="css">
+      <xsl:value-of select="./@end-time" />
+    </xsl:element>
+  </xsl:template>
 
-	<xsl:template match="*" />
+  <xsl:template match="*" />
 </xsl:stylesheet>

--- a/reqreader.xsl
+++ b/reqreader.xsl
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output method="html" indent="yes" encoding="UTF-8" />
+
+	<xsl:template match="acquisition-schedule">
+		<html>
+			<head>
+				<meta charset="UTF-8" />
+				<title>Überflugplan
+				</title>
+				<script type="text/javascript">
+					function switcher(src) {
+					bild = document.getElementById("plot");
+					bild.src = src;
+					bild.visible = true;
+					}
+				</script>
+			</head>
+			<body>
+				<h1>Überflugplan</h1>
+				<h2>
+					Erstellt von:
+					<xsl:value-of select="properties/requested-by" />
+					um:
+					<xsl:value-of select="properties/requested-on" />
+				</h2>
+				<h2>
+					Antenne:
+					<xsl:value-of select="properties/station" />
+				</h2>
+				<table width="90%">
+					<tr>
+						<td>
+							<table style="border-spacing:12px;">
+								<tr>
+									<th>Pass</th>
+									<th>Satellit</th>
+									<th>Aufgang</th>
+									<th>Untergang</th>
+								</tr>
+								<xsl:apply-templates select="child::node()" />
+							</table>
+						</td>
+						<td valign="top" align="right" width="30%">
+							<img id="plot" src="" width="400px" height="300px" visible="false" />
+						</td>
+					</tr>
+				</table>
+			</body>
+		</html>
+	</xsl:template>
+
+	<xsl:attribute-set name="css">
+		<xsl:attribute name="style">font-size:10pt;</xsl:attribute>
+	</xsl:attribute-set>
+
+	<xsl:template match="pass">
+		<xsl:variable name="plotfullname">
+			<xsl:value-of select="./@img" />
+		</xsl:variable>
+		<xsl:variable name="plotname">
+			<xsl:value-of select="substring-after($plotfullname, 'plots.ofb' )" />
+		</xsl:variable>
+		<xsl:element name="tr">
+			<xsl:attribute name="onClick">javascript:switcher('plots.ofb<xsl:value-of select="$plotname" />')</xsl:attribute>
+			<xsl:choose>
+				<xsl:when test="./@rec = 'True'">
+					<xsl:attribute name="style">font-family:monospace; font-weight:bold;</xsl:attribute>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:attribute name="style">font-family:monospace; font-weight:normal;</xsl:attribute>
+				</xsl:otherwise>
+			</xsl:choose>
+			<xsl:call-template name="passvalues">
+				<xsl:with-param name="sat" select="." />
+			</xsl:call-template>
+		</xsl:element>
+	</xsl:template>
+
+	<xsl:template name="passvalues">
+		<xsl:param name="sat" />
+		<td>
+			<xsl:number format="1" />
+		</td>
+		<xsl:element name="td" use-attribute-sets="css">
+			<xsl:value-of select="./@satellite" />
+		</xsl:element>
+		<xsl:element name="td" use-attribute-sets="css">
+			<xsl:value-of select="./@start-time" />
+		</xsl:element>
+		<xsl:element name="td" use-attribute-sets="css">
+			<xsl:value-of select="./@end-time" />
+		</xsl:element>
+	</xsl:template>
+
+	<xsl:template match="*" />
+</xsl:stylesheet>

--- a/scheduler.cfg_template
+++ b/scheduler.cfg_template
@@ -6,10 +6,10 @@ start=2
 
 # dir/file pattern, follows rules of str.format()
 #   pre-set names:
-#   date, time,
-#   station (as in [station]->name, for combined schedules ".comb" is appended),
-#   mode (request|report),
-#   output_dir (as in cmd-param --output-dir)
+#   {date}, time},
+#   {station} (as in [station]->name, for combined schedules ".comb" is appended),
+#   {mode} (request|report),
+#   {output_dir} (as in cmd-param --output-dir)
 [pattern]
 dir_output= {output_dir}/{date}-{time}
 dir_plots= {dir_output}/plots.{station}

--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -84,7 +84,7 @@ class AreaBoundary(Boundary):
             points = np.concatenate(([0], np.arange(start, l, ratio), [l - 1]))
             if points[1] == 0:
                 points = points[1:]
-            if points[-1] == (l - 1):
+            if points[-2] == (l - 1):
                 points = points[:-1]
             self.sides_lons[i] = self.sides_lons[i][points]
             self.sides_lats[i] = self.sides_lats[i][points]

--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -138,6 +138,7 @@ class SwathBoundary(Boundary):
         sgeom = instrument_fun(scans_nb, scanpoints,
                                scan_angle=scan_angle, frequency=frequency)
         times = sgeom.times(utctime)
+
         pixel_pos = geoloc.compute_pixels((self.orb.tle._line1,
                                            self.orb.tle._line2),
                                           sgeom, times)
@@ -161,6 +162,8 @@ class SwathBoundary(Boundary):
                             (overpass.falltime -
                              overpass.risetime).microseconds
                             / 1000000.0) / frequency)
+
+        scans_nb = max(scans_nb, 1)
 
         sides_lons, sides_lats = self.get_instrument_points(self.overpass,
                                                             overpass.risetime,

--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014 Martin Raspaud
+# Copyright (c) 2014, 2015 Martin Raspaud
 
 # Author(s):
 
@@ -82,7 +82,10 @@ class AreaBoundary(Boundary):
             l = len(self.sides_lons[i])
             start = (l % ratio) / 2
             points = np.concatenate(([0], np.arange(start, l, ratio), [l - 1]))
-
+            if points[1] == 0:
+                points = points[1:]
+            if points[-1] == (l - 1):
+                points = points[:-1]
             self.sides_lons[i] = self.sides_lons[i][points]
             self.sides_lats[i] = self.sides_lats[i][points]
 

--- a/trollsched/combine.py
+++ b/trollsched/combine.py
@@ -50,8 +50,8 @@ def add_graphs(graphs, passes, delay=timedelta(seconds=0)):
     for s, g in graphs.items():
         logger.debug("station: %s, order: %d", s, g.order)
 
-    # Gaphs and allpasses are hashmaps of sets or so, but we need lists of lists,
-    # forthat they are copied.
+    # Graphs and allpasses are hashmaps of sets, or similar, but we need 
+    # lists of lists, forthat they are copied.
     grl = []
     pl = []
     for s in statlst:
@@ -296,13 +296,13 @@ def get_combined_sched(allgraphs, allpasses, delay_sec=60):
 
     statlst, newgraph, newpasses = add_graphs(allgraphs, allpasses, delay)
 
-    # >>> DEV: test if the graphs could be "folded".
-    #     for s, g in allgraphs.items():
-    #         print "test folding", s
-    #         test_folding(g)
-    #     print "test folding newgraph"
-    #     if test_folding(newgraph):
-    #         print_matrix(newgraph.adj_matrix, 25, 36)
+    # >>> DEV: test if the graphs could be "folded" to use use less RAM.
+    #for s, g in allgraphs.items():
+    #    print "test folding", s
+    #    test_folding(g)
+    #print "test folding newgraph"
+    #if test_folding(newgraph):
+    #    print_matrix(newgraph.adj_matrix, 25, 36)
     # <<<
 
     dist, path = newgraph.dag_longest_path(0, len(newpasses))

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -186,7 +186,7 @@ class Pass(object):
         rise = self.risetime.strftime("%Y%m%d%H%M%S")
         fall = self.falltime.strftime("%Y%m%d%H%M%S")
         filename = os.path.join(directory,
-                                (rise + self.satellite + fall + extension))
+                                (rise + self.satellite.replace(" ", "_") + fall + extension))
 
         self.fig = filename
         if not overwrite and os.path.exists(filename):

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -160,6 +160,10 @@ class Pass(SimplePass):
             self._boundary = SwathBoundary(self)
         return self._boundary
 
+    @boundary.setter
+    def boundary(self, value):
+        self._boundary = SwathBoundary(self)
+
     def pass_direction(self):
         """Get the direction of the pass in (ascending, descending).
         """

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -100,8 +100,13 @@ class SimplePass(object):
 
     def __eq__(self, other):
 
-        # TODO: the seconds=360 is a workaround to determine if two passes, observed
-        # from two distinct stations, are actually equal (by satellite name and epoch).
+        # TODO: create a different method checking for equality.
+        #
+        # The seconds=360 is a workaround to determine if two passes, observed
+        # from two distinct stations, are actually equal (by satellite name and
+        # epoch).
+        # The value was set as the time difference between two rise times of
+        # one satellite, seen from the two stations Norrköping and Offenbach.
         #
         # Original value from branch develop: seconds=1
         tol = timedelta(seconds=360)

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -324,11 +324,16 @@ def get_aqua_dumps_from_ftp(start_time, end_time, satorb):
         if not filedates[date].endswith(".rpt"):
             continue
         if not os.path.exists(os.path.join("/tmp", filedates[date])):
-            f.retrlines(
-                'RETR ' + os.path.join(url.path, filedates[date]), lines.append)
+            try:
+                f.retrlines(
+                    'RETR ' + os.path.join(url.path, filedates[date]), lines.append)
+            except ftplib.error_perm:
+                logger.info("Permission error (???) on ftp server, skipping.")
+                continue
             with open(os.path.join("/tmp", filedates[date]), "w") as fd_:
                 for line in lines:
                     fd_.write(line + "\n")
+
         else:
             with open(os.path.join("/tmp", filedates[date]), "r") as fd_:
                 for line in fd_:

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -66,26 +66,18 @@ class Mapper(object):
         pass
 
 
-class Pass(object):
+class SimplePass(object):
 
     """A pass: satellite, risetime, falltime, (orbital)
     """
 
     buffer = timedelta(minutes=2)
 
-    def __init__(self, satellite, risetime, falltime, orb=None, uptime=None,
-                 instrument=None, tle1=None, tle2=None):
-
+    def __init__(self, satellite, risetime, falltime):
         self.satellite = satellite
         self.risetime = risetime
         self.falltime = falltime
-        self.uptime = uptime
-        self.instrument = instrument
-        self.orb = orb or orbital.Orbital(satellite, line1=tle1, line2=tle2)
         self.score = {}
-        self.boundary = SwathBoundary(self)
-        # make boundary lighter.
-        # self.boundary.decimate(100)
         self.subsattrack = {"start": None,
                             "end": None}
         self.rec = False
@@ -106,8 +98,9 @@ class Pass(object):
             return 0
 
     def __eq__(self, other):
-        return (self.risetime == other.risetime and
-                self.falltime == other.falltime and
+        tol = timedelta(seconds=1)
+        return (abs(self.risetime - other.risetime) < tol and
+                abs(self.falltime - other.falltime) < tol and
                 self.satellite == other.satellite)
 
     def __str__(self):
@@ -129,6 +122,22 @@ class Pass(object):
         return (duration.days * 24 * 60 * 60
                 + duration.seconds
                 + duration.microseconds * 1e-6)
+
+class Pass(SimplePass):
+
+    """A pass: satellite, risetime, falltime, (orbital)
+    """
+
+
+    def __init__(self, satellite, risetime, falltime, orb=None, uptime=None,
+                 instrument=None, tle1=None, tle2=None):
+        SimplePass.__init__(self, satellite, risetime, falltime)
+        self.uptime = uptime
+        self.instrument = instrument
+        self.orb = orb or orbital.Orbital(satellite, line1=tle1, line2=tle2)
+        self.boundary = SwathBoundary(self)
+
+
 
     def pass_direction(self):
         """Get the direction of the pass in (ascending, descending).

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -460,18 +460,18 @@ def build_filename(pattern_name, pattern_dict, kwargs):
 
 
 def send_file(url, file):
-    pathname, filename = os.path.split(xmlfile)
+    pathname, filename = os.path.split(file)
     del pathname
     if url.scheme in ["file", ""]:
         pass
     elif url.scheme == "ftp":
         import ftplib
         session = ftplib.FTP(url.hostname, url.username, url.password)
-        with open(xmlfile, "rb") as xfile:
+        with open(file, "rb") as xfile:
             session.storbinary('STOR ' + str(filename), xfile)
         session.quit()
     else:
-        logger.error("Cannot save to %s, but file is there:", str(url.scheme), str(xmlfile))
+        logger.error("Cannot save to %s, but file is there:", str(url.scheme), str(file))
 
 
 def single_station(opts, pattern, station, coords, area, scores, start_time, start, forward, tle_file):
@@ -559,19 +559,6 @@ def single_station(opts, pattern, station, coords, area, scores, start_time, sta
                                     )
             logger.info("Generated " + str(xmlfile))
             send_file(url, xmlfile)
-#             pathname, filename = os.path.split(xmlfile)
-#             del pathname
-#             if url.scheme in ["file", ""]:
-#                 pass
-#             elif url.scheme == "ftp":
-#                 import ftplib
-#                 session = ftplib.FTP(url.hostname, url.username, url.password)
-#                 with open(xmlfile, "rb") as xfile:
-#                     session.storbinary('STOR ' + str(filename), xfile)
-#                 session.quit()
-#             else:
-#                 logger.error("Cannot save to %s, but file is there:",
-#                              str(url.scheme), str(xmlfile))
         if opts.report:
             """'If report-mode was set"""
             pattern_args['mode'] = "report"

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -624,7 +624,10 @@ def combined_stations(opts, pattern, station_list, graph, allpasses, start_time,
         # collect labels, each with one pass per station.
         # TODO: is there a simpler way?
         clabels = []
-        npasses = {s:set() for s in stats}
+        if sys.version_info < (2, 7):
+            npasses = dict((s, set() for s in stats))
+        else:
+            npasses = {s:set() for s in stats}
         for npass in newpasses:
             cl = []
             for i, s in zip(range(len(stats)), stats):

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -532,7 +532,7 @@ def run():
     if opts.start_time:
         start_time = opts.start_time
     else:
-        start_time = datetime.utcnow()  # + timedelta(hours=start)
+        start_time = datetime.utcnow()
     allpasses = get_next_passes(satellites, start_time,
                                 forward, coords, tle_file)
 
@@ -573,7 +573,7 @@ def run():
             logger.info("Waiting for images to be saved...")
             image_saver.join()
             logger.info("Done!")
-        xmlfile = generate_xml_file(allpasses, start_time,
+        xmlfile = generate_xml_file(allpasses, start_time + timedelta(hours=start),
                                     start_time + timedelta(hours=forward),
                                     directory, station,
                                     opts.report)

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013, 2014, 2015 Martin Raspaud
+# Copyright (c) 2013, 2014, 2015, 2016 Martin Raspaud
 
 # Author(s):
 
@@ -45,6 +45,9 @@ logger = logging.getLogger(__name__)
 # shortest allowed pass in minutes
 MIN_PASS = 4
 
+# name/id for centre/org creating schedules
+# CENTER_ID = "SMHI"
+CENTER_ID = "DWD-OF"
 
 def conflicting_passes(allpasses, delay=timedelta(seconds=0)):
     """Get the passes in groups of conflicting passes.
@@ -347,7 +350,7 @@ def generate_xml_requests(sched, start, end, station_name, report_mode=False):
     file_end = ET.SubElement(props, "file-end")
     file_end.text = end.strftime(eum_format)
     reqby = ET.SubElement(props, "requested-by")
-    reqby.text = "SMHI"
+    reqby.text = CENTER_ID
     reqon = ET.SubElement(props, "requested-on")
     reqon.text = reqtime.strftime(eum_format)
     for overpass in sorted(sched):
@@ -796,9 +799,11 @@ def run():
 
     # single- or multi-processing?
     if not opts.multiproc:
-        # sequential processing all stations' single scedule.
+        # sequential processing all stations' single schedule.
         for coords, station, area, scores in station_list:
-            graph[station], allpasses[station] = single_station(opts, pattern, station, coords, area, scores, start_time, start, forward, tle_file)
+            graph[station], allpasses[station] = single_station(opts, pattern, station, coords,
+                                                                area, scores, start_time, start,
+                                                                forward, tle_file)
 
     else:
         # processing the stations' single schedules with multiprocessing.

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -544,6 +544,7 @@ def run():
     area.poly = area_boundary.contour_poly
 
     if opts.output_dir is not None:
+        logger.info("Saving plots to %s", opts.output_dir)
         from threading import Thread
         save_passes(allpasses, area.poly, opts.output_dir)
         image_saver = Thread(target=save_passes, args=(allpasses, area.poly, opts.output_dir))


### PR DESCRIPTION
Support coordinated schedules for multiple antennas

The new code to create coordinated schedules for more than one antenna on 
distinct sites is added in the new file combine.py.
A coordinated schedule is antenna-specific, one per antenna is calculated.
The "single antenna" schedule for each antenna is always created, for
un-coordinated operation and as base for coordinated schedules.

Rewrites and additional functionality:
- Move code controlling schedule-/files-creation from **main** to functions.
- Add multiprocessing, creating schedules for single antennas in parallel.
- Make SimplePass more robust.
- Change structure of configuration file:
  - associating the list of receptable satellites with the stations,
  - new: key/value group for filename patterns.

Changes of command-line interface, mostly to improve output path and file names:
- New flag to exclude (default: include) AQUA-dumps.
- Flag to enable multiprocessing.
- Arguments controlling output:
  - most of them are now flags, enabling output of files like SCISYS-schedule,
    graph-dump, passes-list, etc.
  - there's one argument setting one output directory where all files, some
    in sub-directories, are created.
- Re-arrange arguments in argpars.groups for more clarity.
