### PR TITLE
Ensure AVHRR instrument name is suitable for scan geometry calculations

### DIFF
--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -141,6 +141,8 @@ class SwathBoundary(Boundary):
         elif overpass.satellite == "noaa 16":
             scan_angle = 55.25
             instrument = "avhrr"
+        elif "avhrr" in instrument:
+            instrument = "avhrr"
 
         instrument_fun = getattr(geoloc_instrument_definitions, instrument)
 


### PR DESCRIPTION
This PR ensures that "ahvrr-3" and "avhrr/3" are changed to "avhrr" before getting the scan geometry function for boundary calculations.