### PR TITLE
Move save_fig import in under the save function

### DIFF
--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -66,7 +66,6 @@ class SwathBoundary(Boundary):
             instrument = "avhrr"
         else:
             scan_angle = 55.25
-            instrument = 'avhrr'
 
         instrument_fun = getattr(geoloc_instrument_definitions, instrument)
 

--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014-2018 PyTroll community
+# Copyright (c) 2014-2019 PyTroll community
 
 # Author(s):
 
@@ -61,15 +61,19 @@ class SwathBoundary(Boundary):
         elif overpass.satellite == "noaa 16":
             scan_angle = 55.25
             instrument = "avhrr"
+        elif instrument == "mersi2":
+            scan_angle = 55.4
+            instrument = "avhrr"
         else:
             scan_angle = 55.25
+            instrument = 'avhrr'
 
         instrument_fun = getattr(geoloc_instrument_definitions, instrument)
 
         if instrument in ["avhrr", "avhrr/3", "avhrr/2"]:
             sgeom = instrument_fun(scans_nb, scanpoints, scan_angle=scan_angle, frequency=100)
         elif instrument in ["ascat", ]:
-            sgeom = instrument_fun(scans_nb)
+            sgeom = instrument_fun(scans_nb, scanpoints)
         elif instrument in ["olci", ]:
             sgeom = instrument_fun(scans_nb, scanpoints)
         elif instrument == 'viirs':

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014 - 2018 PyTroll Community
+# Copyright (c) 2014 - 2019 PyTroll Community
 # Author(s):
 
 #   Martin Raspaud <martin.raspaud@smhi.se>
@@ -50,6 +50,8 @@ logger = logging.getLogger(__name__)
 
 VIIRS_PLATFORM_NAMES = ['SUOMI NPP', 'SNPP',
                         'NOAA-20', 'NOAA 20']
+MERSI2_PLATFORM_NAMES = ['FENGYUN 3D', 'FENGYUN-3D', 'FY-3D',
+                         'FENGYUN 3E', 'FENGYUN-3E', 'FY-3E']
 
 
 class SimplePass(object):
@@ -141,7 +143,8 @@ class Pass(SimplePass):
         instrument = kwargs.get('instrument', None)
         tle1 = kwargs.get('tle1', None)
         tle2 = kwargs.get('tle2', None)
-        # logger.info("instrument: %s", str(instrument))
+        logger.debug("instrument: %s", str(instrument))
+
         if isinstance(instrument, list):
             logger.warning("Instrument is a list! Assume avhrr...")
             instrument = 'avhrr'
@@ -228,6 +231,7 @@ class Pass(SimplePass):
             area_boundary = area_boundary.contour_poly
 
         inter = self.boundary.contour_poly.intersection(area_boundary)
+
         if inter is None:
             return 0
         return inter.area() / area_boundary.area()
@@ -451,6 +455,8 @@ def get_next_passes(satellites,
                 instrument = "avhrr"
             elif sat.name.upper() in VIIRS_PLATFORM_NAMES:
                 instrument = "viirs"
+            elif sat.name.upper() in MERSI2_PLATFORM_NAMES:
+                instrument = "mersi2"
             else:
                 instrument = "unknown"
 

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2013, 2014, 2015, 2016, 2017, 2018 Martin Raspaud
+# Copyright (c) 2013 - 2019 PyTroll
 
 # Author(s):
 
@@ -602,6 +602,7 @@ def build_filename(pattern_name, pattern_dict, kwargs):
         for v in pattern_dict.values():
             if "{" + k + "}" in v:
                 kwargs[k] = pattern_dict[k].format(**kwargs)
+
     return pattern_dict[pattern_name].format(**kwargs)
 
 

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -43,7 +43,6 @@ from trollsched.graph import Graph
 from trollsched.satpass import get_next_passes, SimplePass
 from pyresample.boundary import AreaDefBoundary
 from trollsched.combine import get_combined_sched
-from trollsched.drawing import save_fig
 
 
 logger = logging.getLogger(__name__)
@@ -576,6 +575,7 @@ def parse_datetime(strtime):
 def save_passes(allpasses, poly, output_dir):
     """Save overpass plots to png and store in directory *output_dir*
     """
+    from trollsched.drawing import save_fig
     for overpass in allpasses:
         save_fig(overpass, poly=poly, directory=output_dir)
 

--- a/trollsched/tests/test_satpass.py
+++ b/trollsched/tests/test_satpass.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Adam.Dybbroe
+# Copyright (c) 2018 - 2019 PyTroll
 
 # Author(s):
 
-#   Adam.Dybbroe <a000680@c20671.ad.smhi.se>
+#   Adam.Dybbroe <adam.dybbroe@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@
 
 import unittest
 import numpy as np
-from datetime import datetime
+from datetime import datetime, timedelta
 from trollsched.satpass import Pass
 from trollsched.boundary import SwathBoundary
 from pyorbital.orbital import Orbital
@@ -244,6 +244,16 @@ class TestSwathBoundary(unittest.TestCase):
         overp = Pass('NOAA-19', tstart, tend, orb=self.n19orb, instrument='avhrr', frequency=300)
 
         cov = overp.area_coverage(self.euron1)
+        self.assertAlmostEqual(cov, 0.103526, 5)
+
+        # ASCAT and AVHRR on Metop-B:
+        tstart = datetime.strptime("2019-01-02T10:19:39", "%Y-%m-%dT%H:%M:%S")
+        tend = tstart + timedelta(seconds=180)
+        tle1 = '1 38771U 12049A   19002.35527803  .00000000  00000+0  21253-4 0 00017'
+        tle2 = '2 38771  98.7284  63.8171 0002025  96.0390 346.4075 14.21477776326431'
+
+        mypass = Pass('Metop-B', tstart, tend, instrument='ascat', tle1=tle1, tle2=tle2)
+        acov = mypass.area_coverage(self.euron1)
         self.assertAlmostEqual(cov, 0.103526, 5)
 
     def tearDown(self):

--- a/trollsched/tests/test_satpass.py
+++ b/trollsched/tests/test_satpass.py
@@ -260,6 +260,17 @@ class TestSwathBoundary(unittest.TestCase):
         cov = mypass.area_coverage(self.euron1)
         self.assertAlmostEqual(cov, 0.357324, 5)
 
+        tstart = datetime.strptime("2019-01-05T01:01:45", "%Y-%m-%dT%H:%M:%S")
+        tend = tstart + timedelta(seconds=60*15.5)
+
+        tle1 = '1 43010U 17072A   18363.54078832 -.00000045  00000-0 -79715-6 0  9999'
+        tle2 = '2 43010  98.6971 300.6571 0001567 143.5989 216.5282 14.19710974 58158'
+
+        mypass = Pass('FENGYUN 3D', tstart, tend, instrument='mersi2', tle1=tle1, tle2=tle2)
+        cov = mypass.area_coverage(self.euron1)
+
+        self.assertAlmostEqual(cov, 0.786836, 5)
+
     def tearDown(self):
         """Clean up"""
         pass

--- a/trollsched/tests/test_schedule.py
+++ b/trollsched/tests/test_schedule.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014, 2018 Martin Raspaud
+# Copyright (c) 2014 - 2019 PyTroll
 
 # Author(s):
 
 #   Martin Raspaud <martin.raspaud@smhi.se>
+#   Adam Dybbroe <adam.dybbroe@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,6 +28,7 @@ import numpy as np
 from datetime import datetime, timedelta
 
 from trollsched.schedule import fermia, fermib, conflicting_passes
+from trollsched.schedule import parse_datetime, build_filename
 from pyresample.boundary import AreaBoundary
 from trollsched.satpass import get_next_passes
 from trollsched.satpass import get_aqua_terra_dumps
@@ -151,6 +153,27 @@ class TestUtils(unittest.TestCase):
     def test_fermi(self):
         self.assertEquals(fermia(0.25), 0.875)
         self.assertEquals(fermib(0.25), 0.5)
+
+    def test_parse_datetime(self):
+
+        dtobj = parse_datetime('20190104110059')
+        self.assertEqual(dtobj, datetime(2019, 1, 4, 11, 0, 59))
+
+    def test_build_filename(self):
+
+        pattern_name = "dir_output"
+        pattern_dict = {'file_xml': '{dir_output}/{date}-{time}-aquisition-schedule-{mode}-{station}.xml', 'file_sci': '{dir_output}/scisys-schedule-{station}.txt',
+                        'dir_plots': '{dir_output}/plots.{station}', 'dir_output': '/tmp', 'file_graph': '{dir_output}/graph.{station}'}
+        kwargs = {'date': '20190104', 'output_dir': '.', 'dir_output': '/tmp', 'time': '122023'}
+
+        res = build_filename(pattern_name, pattern_dict, kwargs)
+        self.assertEqual(res, '/tmp')
+
+        pattern_name = "file_xml"
+        kwargs = {'station': 'nrk', 'mode': 'request', 'time': '125334',
+                  'date': '20190104', 'dir_output': '/tmp', 'output_dir': '.'}
+        res = build_filename(pattern_name, pattern_dict, kwargs)
+        self.assertEqual(res, '/tmp/20190104-125334-aquisition-schedule-request-nrk.xml')
 
 
 class TestAll(unittest.TestCase):


### PR DESCRIPTION
Signed-off-by: Adam Dybbroe <Adam.Dybbroe@smhi.se>

Make it possible to run without matplotlib. matplotlib should only be needed when making plots

 - [x] Tests updated
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

