### PR TITLE
Make sure avhrr/3 and avhrr/2 are interpreted as avhrr

### DIFF
--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -35,6 +35,9 @@ from pyorbital import geoloc, geoloc_instrument_definitions
 
 logger = logging.getLogger(__name__)
 
+INSTRUMENT = {'avhrr/3': 'avhrr',
+              'avhrr/2': 'avhrr'}
+
 
 class SwathBoundary(Boundary):
 
@@ -67,7 +70,7 @@ class SwathBoundary(Boundary):
         else:
             scan_angle = 55.25
 
-        instrument_fun = getattr(geoloc_instrument_definitions, instrument)
+        instrument_fun = getattr(geoloc_instrument_definitions, INSTRUMENT.get(instrument, instrument))
 
         if instrument in ["avhrr", "avhrr/3", "avhrr/2"]:
             sgeom = instrument_fun(scans_nb, scanpoints, scan_angle=scan_angle, frequency=100)


### PR DESCRIPTION
Signed-off-by: Adam Dybbroe <Adam.Dybbroe@smhi.se>

Bugfix: Giving instrument names avhrr/3 and avhrr/2 were not working

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
