### PR TITLE
Add testing of the avhrr/3 naming

### DIFF
--- a/trollsched/tests/test_satpass.py
+++ b/trollsched/tests/test_satpass.py
@@ -207,6 +207,14 @@ class TestSwathBoundary(unittest.TestCase):
         assertNumpyArraysEqual(cont[0], LONS3)
         assertNumpyArraysEqual(cont[1], LATS3)
 
+        overp = Pass('NOAA-19', tstart, tend, orb=self.n19orb, instrument='avhrr/3')
+        overp_boundary = SwathBoundary(overp, frequency=500)
+
+        cont = overp_boundary.contour()
+
+        assertNumpyArraysEqual(cont[0], LONS3)
+        assertNumpyArraysEqual(cont[1], LATS3)
+
     def test_swath_coverage(self):
 
         # NOAA-19 AVHRR:
@@ -236,7 +244,7 @@ class TestSwathBoundary(unittest.TestCase):
         cov = overp.area_coverage(self.euron1)
         self.assertAlmostEqual(cov, 0.103526, 5)
 
-        overp = Pass('NOAA-19', tstart, tend, orb=self.n19orb, instrument='avhrr', frequency=133)
+        overp = Pass('NOAA-19', tstart, tend, orb=self.n19orb, instrument='avhrr/3', frequency=133)
 
         cov = overp.area_coverage(self.euron1)
         self.assertAlmostEqual(cov, 0.103526, 5)


### PR DESCRIPTION
Signed-off-by: Adam Dybbroe <Adam.Dybbroe@smhi.se>

Forgot to push the updated test-scripts covering the avhrr/3 naming - part of the previous PR

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
