### PR TITLE
Bugfix avhrr naming

### DIFF
--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -36,7 +36,8 @@ from pyorbital import geoloc, geoloc_instrument_definitions
 logger = logging.getLogger(__name__)
 
 INSTRUMENT = {'avhrr/3': 'avhrr',
-              'avhrr/2': 'avhrr'}
+              'avhrr/2': 'avhrr',
+              'avhrr-3': 'avhrr'}
 
 
 class SwathBoundary(Boundary):
@@ -70,9 +71,10 @@ class SwathBoundary(Boundary):
         else:
             scan_angle = 55.25
 
-        instrument_fun = getattr(geoloc_instrument_definitions, INSTRUMENT.get(instrument, instrument))
+        instrument_fun = getattr(geoloc_instrument_definitions,
+                                 INSTRUMENT.get(instrument, instrument))
 
-        if instrument in ["avhrr", "avhrr/3", "avhrr/2"]:
+        if instrument.startswith("avhrr"):
             sgeom = instrument_fun(scans_nb, scanpoints, scan_angle=scan_angle, frequency=100)
         elif instrument in ["ascat", ]:
             sgeom = instrument_fun(scans_nb, scanpoints)
@@ -112,7 +114,7 @@ class SwathBoundary(Boundary):
         if self.overpass.instrument == 'viirs':
             sec_scan_duration = 1.779166667
             along_scan_reduce_factor = 1
-        elif self.overpass.instrument in ['avhrr', 'avhrr/3', 'avhrr/2']:
+        elif self.overpass.instrument.startswith("avhrr"):
             sec_scan_duration = 1./6.
             along_scan_reduce_factor = 0.1
         elif self.overpass.instrument == 'ascat':

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -451,10 +451,10 @@ def get_next_passes(satellites,
             get_terra_aqua_passes(passes, utctime, forward, sat, passlist, satorb, aqua_terra_dumps)
 
         else:
-            if sat.name.lower().startswith("metop") or sat.name.lower().startswith("noaa"):
-                instrument = "avhrr"
-            elif sat.name.upper() in VIIRS_PLATFORM_NAMES:
+            if sat.name.upper() in VIIRS_PLATFORM_NAMES:
                 instrument = "viirs"
+            elif sat.name.lower().startswith("metop") or sat.name.lower().startswith("noaa"):
+                instrument = "avhrr"
             elif sat.name.upper() in MERSI2_PLATFORM_NAMES:
                 instrument = "mersi2"
             else:

--- a/trollsched/tests/test_satpass.py
+++ b/trollsched/tests/test_satpass.py
@@ -215,6 +215,14 @@ class TestSwathBoundary(unittest.TestCase):
         assertNumpyArraysEqual(cont[0], LONS3)
         assertNumpyArraysEqual(cont[1], LATS3)
 
+        overp = Pass('NOAA-19', tstart, tend, orb=self.n19orb, instrument='avhrr-3')
+        overp_boundary = SwathBoundary(overp, frequency=500)
+
+        cont = overp_boundary.contour()
+
+        assertNumpyArraysEqual(cont[0], LONS3)
+        assertNumpyArraysEqual(cont[1], LATS3)
+
     def test_swath_coverage(self):
 
         # NOAA-19 AVHRR:


### PR DESCRIPTION
This PR fixes a bug that `'avhrr-3'` (name used in SatPy) isn't recognized as AVHRR instrument. Also ensures that `'noaa-20'` and `'NOAA-20'` are properly interpreted as platforms for VIIRS.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
