### PR TITLE
Fix S3 olci scan duration

### DIFF
--- a/trollsched/__init__.py
+++ b/trollsched/__init__.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014, 2018 PyTroll Community
+# Copyright (c) 2014 - 2019 PyTroll Community
 
 # Author(s):
 
 #   Martin Raspaud <martin.raspaud@smhi.se>
+#   Adam Dybbroe <adam.dybbroe@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,6 +39,8 @@ NUMBER_OF_FOVS = {
     'avhrr': 2048,
     'mhs': 90,
     'amsua': 30,
+    'mwhs2': 98,
+    'atms': 96,
     'ascat': 42,
     'viirs': 6400
 }

--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -81,6 +81,10 @@ class SwathBoundary(Boundary):
             sgeom = instrument_fun(scans_nb, scanpoints, scan_angle=scan_angle, frequency=100)
         elif instrument in ["ascat", ]:
             sgeom = instrument_fun(scans_nb, scanpoints)
+        elif instrument in ["amsua", 'mhs']:
+            sgeom = instrument_fun(scans_nb, scanpoints)
+        elif instrument in ["mwhs2", ]:
+            sgeom = instrument_fun(scans_nb, scanpoints)
         elif instrument in ["olci", ]:
             sgeom = instrument_fun(scans_nb, scanpoints)
         elif instrument == 'viirs':
@@ -102,7 +106,6 @@ class SwathBoundary(Boundary):
 
     def __init__(self, overpass, scan_step=50, frequency=200):
         # compute area covered by pass
-
         Boundary.__init__(self)
 
         self.overpass = overpass
@@ -122,6 +125,21 @@ class SwathBoundary(Boundary):
             along_scan_reduce_factor = 0.1
         elif self.overpass.instrument == 'ascat':
             sec_scan_duration = 3.74747474747
+            along_scan_reduce_factor = 1
+            # Overwrite the scan step
+            scan_step = 1
+        elif self.overpass.instrument == 'amsua':
+            sec_scan_duration = 8.
+            along_scan_reduce_factor = 1
+            # Overwrite the scan step
+            scan_step = 1
+        elif self.overpass.instrument == 'mhs':
+            sec_scan_duration = 8./3.
+            along_scan_reduce_factor = 1
+            # Overwrite the scan step
+            scan_step = 1
+        elif self.overpass.instrument == 'mwhs2':
+            sec_scan_duration = 8./3.
             along_scan_reduce_factor = 1
             # Overwrite the scan step
             scan_step = 1
@@ -152,6 +170,13 @@ class SwathBoundary(Boundary):
 
         side_shape = sides_lons[::-1, 0].shape[0]
         nmod = 1
+
+        # Devide by the scan step to a reduced number of scans:
+        scans_nb = scanlength_seconds / sec_scan_duration * along_scan_reduce_factor
+        scan_step = 10  # Valid for MHS/AMSU-S/MWHS-2 only
+        scans_nb = np.floor(scans_nb / scan_step)
+        scans_nb = int(max(scans_nb, 1))
+
         if side_shape != scans_nb:
             nmod = side_shape // scans_nb
             logger.debug('Number of scan lines (%d) does not match number of scans (%d)',
@@ -191,6 +216,8 @@ class SwathBoundary(Boundary):
         self.top_lons = lons[0]
         self.top_lats = lats[0]
 
+        return
+
     def decimate(self, ratio):
         l = len(self.top_lons)
         start = (l % ratio) / 2
@@ -209,6 +236,8 @@ class SwathBoundary(Boundary):
         self.right_lats = self.right_lats[points]
         self.left_lons = self.left_lons[points]
         self.left_lats = self.left_lats[points]
+
+        return
 
     def contour(self):
         lons = np.concatenate((self.top_lons,

--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -122,6 +122,12 @@ class SwathBoundary(Boundary):
             along_scan_reduce_factor = 1
             # Overwrite the scan step
             scan_step = 1
+        elif self.overpass.instrument == 'olci':
+            # 3 minutes of data is 4091 300meter lines:
+            sec_scan_duration = 0.04399902224395014
+            along_scan_reduce_factor = 1
+            # Overwrite the scan step
+            scan_step = 100
         else:
             # Assume AVHRR!
             logmsg = ("Instrument scan duration not known. Setting it to AVHRR. Instrument: ")
@@ -131,7 +137,7 @@ class SwathBoundary(Boundary):
 
         # From pass length in seconds and the seconds for one scan derive the number of scans in the swath:
         scans_nb = scanlength_seconds/sec_scan_duration * along_scan_reduce_factor
-        # Devide by the scan step to a reduced number of scans:
+        # Devide by the scan step to reduced number of scans:
         scans_nb = np.floor(scans_nb/scan_step)
         scans_nb = int(max(scans_nb, 1))
 

--- a/trollsched/drawing.py
+++ b/trollsched/drawing.py
@@ -178,7 +178,6 @@ def save_fig(pass_obj,
         mapper.nightshade(pass_obj.uptime, alpha=0.2)
         logger.debug("Draw: outline = <%s>", outline)
         draw(pass_obj.boundary.contour_poly, mapper, outline)
-        #draw(pass_obj.boundary.contour_poly, mapper, '*r')
         if poly is not None:
             draw(poly, mapper, "-b")
 

--- a/trollsched/drawing.py
+++ b/trollsched/drawing.py
@@ -163,9 +163,10 @@ def save_fig(pass_obj,
     if not os.path.exists(directory):
         logger.debug("Create plot dir " + directory)
         os.makedirs(directory)
+
     filename = os.path.join(
         directory,
-        (rise + pass_obj.satellite.name.replace(" ", "_") + fall + extension))
+        (rise + pass_obj.satellite.name.replace(" ", "_") + fall + '_' + pass_obj.instrument + extension))
 
     pass_obj.fig = filename
     if not overwrite and os.path.exists(filename):
@@ -177,11 +178,15 @@ def save_fig(pass_obj,
         mapper.nightshade(pass_obj.uptime, alpha=0.2)
         logger.debug("Draw: outline = <%s>", outline)
         draw(pass_obj.boundary.contour_poly, mapper, outline)
+        #draw(pass_obj.boundary.contour_poly, mapper, '*r')
         if poly is not None:
             draw(poly, mapper, "-b")
 
     logger.debug("Title = %s", str(pass_obj))
-    plt.title(str(pass_obj))
+    if not plot_title:
+        plt.title(str(pass_obj))
+    else:
+        plt.title(plot_title)
     for label in labels or []:
         plt.figtext(*label[0], **label[1])
     logger.debug("Save plot...")


### PR DESCRIPTION
Adding OLCI scan duration. Before it assumed AVHRR scan speed

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
