### PR TITLE
Fix nasa ftp retrieval

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,9 @@
+linters:
+  flake8:
+    python: 3
+    config: setup.cfg
+
+files:
+    ignore:
+        - 'docs/Makefile'
+        - 'docs/make.bat'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='sphinx cartopy scipy numpy coveralls coverage codecov behave mock pycoast pydecorate six appdirs pykdtree pyresample docutils pyyaml matplotlib'
+  - CONDA_DEPENDENCIES='sphinx cartopy scipy coveralls coverage codecov behave mock pycoast pydecorate six appdirs pykdtree pyresample docutils pyyaml matplotlib'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request cron'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='scipy coveralls coverage codecov mock six appdirs pykdtree pyresample docutils pyyaml matplotlib xarray'
+  - CONDA_DEPENDENCIES='dask distributed toolz Cython sphinx cartopy pillow scipy coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio<1.0.14 imageio pyhdf mock libtiff pycoast pydecorate geoviews six appdirs pykdtree pyresample docutils pyyaml matplotlib xarray'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request cron'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
   - NUMPY_VERSION=stable
   - MAIN_CMD='python setup.py'
-  - CONDA_DEPENDENCIES='dask distributed toolz Cython sphinx cartopy pillow scipy coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio<1.0.14 imageio pyhdf mock libtiff pycoast pydecorate geoviews six appdirs pykdtree pyresample docutils pyyaml matplotlib xarray'
+  - CONDA_DEPENDENCIES='sphinx cartopy scipy numpy coveralls coverage codecov behave mock pycoast pydecorate six appdirs pykdtree pyresample docutils pyyaml matplotlib'
   - PIP_DEPENDENCIES=''
   - SETUP_XVFB=False
   - EVENT_TYPE='push pull_request cron'

--- a/generate_schedule_xmlpage.py
+++ b/generate_schedule_xmlpage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016, 2018 Adam.Dybbroe
+# Copyright (c) 2016, 2018, 2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -26,14 +26,11 @@ schedule request xml files and then triggers the png and xml output generation.
 
 """
 
-import os
-from six.moves.configparser import RawConfigParser
 import logging
 import sys
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
+import os
+from six.moves.configparser import RawConfigParser
+from six.moves.urllib.parse import urlparse
 import posttroll.subscriber
 from posttroll.publisher import Publish
 import xml.etree.ElementTree as ET

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014 - 2018 PyTroll Community
+# Copyright (c) 2014 - 2019 PyTroll Community
 
 # Author(s):
 
@@ -30,7 +30,7 @@ import sys
 import versioneer
 
 requires = ['numpy', 'pyresample', 'pyorbital']
-test_requires = ['satpy']
+test_requires = []
 
 if sys.version_info < (2, 7):
     # multiprocessing is not in the standard library

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -333,7 +333,7 @@ def get_aqua_terra_dumpdata_from_ftp(sat, dump_url):
         url = urlparse(HOST % sat.name)
     logger.debug("Connect to ftp server")
     try:
-        f = ftplib.FTP(url.netloc)
+        f = ftplib.FTP_TLS(url.netloc)
     except (socket.error, socket.gaierror) as e:
         logger.error('cannot reach to %s ' % HOST + str(e))
         f = None

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -32,11 +32,7 @@ import os
 import six
 import socket
 from functools import reduce as fctools_reduce
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-
+from six.moves.urllib.parse import urlparse
 from datetime import datetime, timedelta
 from tempfile import mkstemp
 import numpy as np

--- a/trollsched/satpass.py
+++ b/trollsched/satpass.py
@@ -350,6 +350,7 @@ def get_aqua_terra_dumpdata_from_ftp(sat, dump_url):
     if f is not None:
         data = []
         try:
+            f.prot_p()  # explicitly call for protected transfer
             f.dir(url.path, data.append)
         except socket.error as e:
             logger.error("Can't get any data: " + str(e))
@@ -377,6 +378,7 @@ def get_aqua_terra_dumpdata_from_ftp(sat, dump_url):
         lines = []
         if not os.path.exists(os.path.join("/tmp", filedates[date])):
             try:
+                f.prot_p()  # explicitly call for protected transfer
                 f.retrlines('RETR ' + os.path.join(url.path, filedates[date]),
                             lines.append)
             except ftplib.error_perm:

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -36,7 +36,7 @@ from pprint import pformat
 
 import numpy as np
 from pyorbital import astronomy
-from pyresample import utils as resample_utils
+from pyresample import parse_area_file
 from trollsched import utils
 from trollsched.spherical import get_twilight_poly
 from trollsched.graph import Graph
@@ -67,7 +67,7 @@ class Station(object):
 
         if area_file is not None:
             try:
-                self.area = resample_utils.parse_area_file(area_file, area)[0]
+                self.area = parse_area_file(area_file, area)[0]
             except TypeError:
                 pass
 

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -36,7 +36,12 @@ from pprint import pformat
 
 import numpy as np
 from pyorbital import astronomy
-from pyresample import parse_area_file
+try:
+    from pyresample import parse_area_file
+except ImportError:
+    # Older versions of pyresample:
+    from pyresample.utils import parse_area_file
+
 from trollsched import utils
 from trollsched.spherical import get_twilight_poly
 from trollsched.graph import Graph

--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -26,11 +26,7 @@
 import logging
 import logging.handlers
 import os
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-
+from six.moves.urllib.parse import urlparse
 from datetime import datetime, timedelta
 from pprint import pformat
 

--- a/trollsched/tests/test_satpass.py
+++ b/trollsched/tests/test_satpass.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta
 from trollsched.satpass import Pass
 from trollsched.boundary import SwathBoundary
 from pyorbital.orbital import Orbital
-
+from pyresample.geometry import AreaDefinition
 
 LONS1 = np.array([-122.29913729160562, -131.54385362589042, -155.788034272281,
                   143.1730880418349, 105.69172088208997, 93.03135571771092,
@@ -128,6 +128,11 @@ LATS3 = np.array([66.94713585, 67.07854554, 66.53108388, 65.27837805, 63.5022359
                   58.33858588, 57.71210872, 55.14964148, 55.72506407, 60.40889798,
                   61.99561474, 63.11425455, 63.67173255, 63.56939058], dtype='float64')
 
+AREA_DEF_EURON1 = AreaDefinition('euron1', 'Northern Europe - 1km',
+                                 '', {'proj': 'stere', 'ellps': 'WGS84',
+                                      'lat_0': 90.0, 'lon_0': 0.0, 'lat_ts': 60.0},
+                                 3072, 3072, (-1000000.0, -4500000.0, 2072000.0, -1428000.0))
+
 
 def assertNumpyArraysEqual(self, other):
     if self.shape != other.shape:
@@ -152,15 +157,6 @@ def get_n19_orbital():
     tle1 = "1 33591U 09005A   18288.64852564  .00000055  00000-0  55330-4 0  9992"
     tle2 = "2 33591  99.1559 269.1434 0013899 353.0306   7.0669 14.12312703499172"
     return Orbital('NOAA-19', line1=tle1, line2=tle2)
-
-
-def get_region(areaid):
-    try:
-        from satpy.resample import get_area_def
-    except ImportError:
-        from mpop.projector import get_area_def
-
-    return get_area_def(areaid)
 
 
 class TestPass(unittest.TestCase):
@@ -198,7 +194,7 @@ class TestSwathBoundary(unittest.TestCase):
         """Set up"""
         self.n20orb = get_n20_orbital()
         self.n19orb = get_n19_orbital()
-        self.euron1 = get_region('euron1')
+        self.euron1 = AREA_DEF_EURON1
 
     def test_swath_boundary(self):
 


### PR DESCRIPTION
NASA has changed to no longer support plain FTP access for reasons of security.  Only FTPS or HTTPS is now supported by these servers.

Now we use ftplib.FTP_TLS instead of ftplib.FTP to connect to the nasa server in order to download Aqua/Terra downlink schedules

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
