### PR TITLE
Make it possible to tell cartopy to use offline shapefiles

### DIFF
--- a/trollsched/drawing.py
+++ b/trollsched/drawing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Adam.Dybbroe
+# Copyright (c) 2018, 2019 Adam.Dybbroe
 
 # Author(s):
 
@@ -39,6 +39,11 @@ try:
 except ImportError:
     logger.warning("Failed loading Cartopy, will try Basemap instead")
     BASEMAP_NOT_CARTOPY = True
+
+if not BASEMAP_NOT_CARTOPY:
+    import cartopy
+    cartopy.config['pre_existing_data_dir'] = os.environ.get(
+        "CARTOPY_PRE_EXISTING_DATA_DIR", cartopy.config['pre_existing_data_dir'])
 
 
 class MapperBasemap(object):


### PR DESCRIPTION
Set environment variable for cartopy in order to use offline shapefiles


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
