### PR TITLE
Remove a bug introduced in PR38

### DIFF
--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -180,12 +180,6 @@ class SwathBoundary(Boundary):
         side_shape = sides_lons[::-1, 0].shape[0]
         nmod = 1
 
-        # Devide by the scan step to a reduced number of scans:
-        scans_nb = scanlength_seconds / sec_scan_duration * along_scan_reduce_factor
-        scan_step = 10  # Valid for MHS/AMSU-S/MWHS-2 only
-        scans_nb = np.floor(scans_nb / scan_step)
-        scans_nb = int(max(scans_nb, 1))
-
         if side_shape != scans_nb:
             nmod = side_shape // scans_nb
             logger.debug('Number of scan lines (%d) does not match number of scans (%d)',


### PR DESCRIPTION
This PR removes a buggy bit of code introduced to `master`/`main` branch by pre-mature merging fo PR #38.

This fixes the usage of geographic granule gathering in Pytroll Collectors. There's no intention by the author to do any other fixes on this PR, the only point is to make `main` branch to work again.

 - [x] Closes #52 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
