### PR TITLE
Fix an import raising deprecation warning

### DIFF
--- a/trollsched/boundary.py
+++ b/trollsched/boundary.py
@@ -180,12 +180,6 @@ class SwathBoundary(Boundary):
         side_shape = sides_lons[::-1, 0].shape[0]
         nmod = 1
 
-        # Devide by the scan step to a reduced number of scans:
-        scans_nb = scanlength_seconds / sec_scan_duration * along_scan_reduce_factor
-        scan_step = 10  # Valid for MHS/AMSU-S/MWHS-2 only
-        scans_nb = np.floor(scans_nb / scan_step)
-        scans_nb = int(max(scans_nb, 1))
-
         if side_shape != scans_nb:
             nmod = side_shape // scans_nb
             logger.debug('Number of scan lines (%d) does not match number of scans (%d)',

--- a/trollsched/utils.py
+++ b/trollsched/utils.py
@@ -25,7 +25,7 @@
 
 import yaml
 import logging
-from collections import Mapping
+from collections.abc import Mapping
 from six.moves.configparser import ConfigParser
 
 try:


### PR DESCRIPTION
The current import `from collections import Mapping` raises a `DeprecationWarning` stating that it won't work in Python 3.9. This fixes the import.

 - [x] Closes #54  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
