### PR TITLE
Fix a test failure on Python 3.7

### DIFF
--- a/trollsched/tests/test_satpass.py
+++ b/trollsched/tests/test_satpass.py
@@ -405,7 +405,9 @@ class TestPassList(unittest.TestCase):
         coords = (10.72, 59.942, 0.1)
         mypass.generate_metno_xml(coords, root)
 
-        self.assertEqual(ET.tostring(root).decode("utf-8"), orig)
+        # Dictionaries don't have guaranteed ordering in Python 3.7, so convert the strings to sets and compare them
+        res = set(ET.tostring(root).decode("utf-8").split())
+        self.assertEqual(res, set(orig.split()))
 
     def tearDown(self):
         """Clean up"""


### PR DESCRIPTION
This PR adds a workaround for a test failure with Python 3.7. With Python 3.7 the XML item ordering isn't retained for some reason, so comparison of the string representations of the XML doesn't work.

 - [x] Relevant tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
