### PR TITLE
Use safe loading for YAML config file

### DIFF
--- a/trollsched/utils.py
+++ b/trollsched/utils.py
@@ -44,7 +44,7 @@ def read_yaml_file(file_name):
     conf_dict = {}
     for file_obj in file_name:
         with open(file_obj) as fp:
-            tmp_dict = yaml.load(fp)
+            tmp_dict = yaml.safe_load(fp)
         conf_dict = recursive_dict_update(conf_dict, tmp_dict)
     return conf_dict
 


### PR DESCRIPTION
Pyyaml 6.0 requires the loader to be defined for YAML reading. This PR switches from `yaml.load()` to `yaml.safe_load()` for reading the config file.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
