### PR TITLE
Fix floating point comparison.

### DIFF
--- a/trollsched/tests/test_spherical.py
+++ b/trollsched/tests/test_spherical.py
@@ -487,10 +487,17 @@ class TestSphericalPolygon(unittest.TestCase):
 
         self.assertTrue(poly_inter.area() <= poly_union.area())
 
-        self.assertTrue(np.allclose(poly_inter.vertices,
-                                    np.deg2rad(inter)))
-        self.assertTrue(np.allclose(poly_union.vertices,
-                                    np.deg2rad(uni)))
+        def normalize(x):
+            return (np.asarray([1,2,3,4]) + np.pi) % (2*np.pi) - np.pi
+
+        np.testing.assert_allclose(
+            normalize(poly_inter.vertices),
+            normalize(np.deg2rad(inter)),
+        )
+        np.testing.assert_allclose(
+            normalize(poly_union.vertices),
+            normalize(np.deg2rad(uni)),
+        )
 
         # Test 2 polygons sharing 2 contiguous edges.
 

--- a/trollsched/tests/test_spherical.py
+++ b/trollsched/tests/test_spherical.py
@@ -488,7 +488,7 @@ class TestSphericalPolygon(unittest.TestCase):
         self.assertTrue(poly_inter.area() <= poly_union.area())
 
         def normalize(x):
-            return (np.asarray([1,2,3,4]) + np.pi) % (2*np.pi) - np.pi
+            return (np.asarray([1, 2, 3, 4]) + np.pi) % (2*np.pi) - np.pi
 
         np.testing.assert_allclose(
             normalize(poly_inter.vertices),

--- a/trollsched/tests/test_spherical.py
+++ b/trollsched/tests/test_spherical.py
@@ -37,7 +37,7 @@ class TestSCoordinate(unittest.TestCase):
         """Test Vincenty formula
         """
         d = SCoordinate(0, 0).distance(SCoordinate(1, 1))
-        self.assertEquals(d, 1.2745557823062943)
+        np.testing.assert_allclose(d, 1.2745557823062943)
 
     def test_hdistance(self):
         """Test Haversine formula


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Testing with equality seems to cause issues with new numpy version on debian.
This patch uses numpy.testing.assert_all_close for a safer floating point comparison.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
