### PR TITLE
Update CI Python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
         experimental: [false]
     steps:
       - name: Checkout source


### PR DESCRIPTION
Update CI Python versions to 3.10, 3.11 and 3.12.