### PR TITLE
Save scheduled passes to metnoformat  xml 

### DIFF
--- a/trollsched/schedule.py
+++ b/trollsched/schedule.py
@@ -137,7 +137,11 @@ class Station:
             logger.info("Done!")
 
         if opts.metno_xml:
-            generate_metno_xml_file(build_filename("file_metno_xml", pattern, pattern_args), allpasses,
+            generate_metno_xml_file(build_filename("file_metno_xml_all", pattern, pattern_args), allpasses,
+                                    self.coords, start_time + timedelta(hours=sched.start),
+                                    start_time + timedelta(hours=sched.forward), self.id, sched.center_id,
+                                    report_mode=True)
+            generate_metno_xml_file(build_filename("file_metno_xml", pattern, pattern_args), schedule,
                                     self.coords, start_time + timedelta(hours=sched.start),
                                     start_time + timedelta(hours=sched.forward), self.id, sched.center_id,
                                     report_mode=True)

--- a/trollsched/writers.py
+++ b/trollsched/writers.py
@@ -41,7 +41,7 @@ def generate_sch_file(output_file, overpasses, coords):
 
 def generate_metno_xml_file(output_file, allpasses, coords, start, end, station_name, center_id, report_mode=False):
     """Generate a meto xml file."""
-    import defusedxml.ElementTree as ET
+    from xml.etree import ElementTree as ET  # noqa
 
     reqtime = datetime.utcnow()
     time_format = "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

For some reason only the allpasses was written for metno format xml. I also need the schedules passes as a separate file.

PLease note this PR need PR #102 the be merged first.

 - [X] Closes #103  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/main **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
